### PR TITLE
[FIX] | loading initial code when document.cookie is empty

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -91,6 +91,9 @@ class App extends Component {
     window.onrelod = this.saveCurrentCode;
     let cookies = document.cookie.split(';').filter(item => item.includes("assemblyCode"));
     let savedCode = cookies[0];
+    if (!savedCode) {
+      return INITIALCODE
+    }
     savedCode = helpers.replaceInString(savedCode, "assemblyCode=", "");
     savedCode = helpers.replaceInString(savedCode, "{{{{,}}}}", "\n");
     savedCode = helpers.replaceInString(savedCode, "{{{{:}}}}", ";");


### PR DESCRIPTION
As we've started to save the current code in **document.cookie**, this wasn't working when loading the simulator for the first time since document.cookie will be empty.

Ideally, document.cookie is not the right place to save the code, cookies are supposed to go back and forth while making HTTP calls which is not the case here. 

We should be using localStorage to achieve this, which can be done incrementally. :)

[https://medium.com/datadriveninvestor/cookies-vs-local-storage-2f3732c7d977](https://medium.com/datadriveninvestor/cookies-vs-local-storage-2f3732c7d977)